### PR TITLE
docs: add setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,29 @@ The key pages for this application are:
 - Husky
 - ESlint + Prettier
 
+## Setting up locally
+
+1. Clone the repository:
+```bash
+git clone https://github.com/SchemingCate/eCommerce-app.git
+```
+2. Go to the project folder:
+```bash
+cd eCommerce-app
+```
+3. Install dependencies
+```bash
+npm i
+```
+
+To see preview run:
+```
+npm run preview
+```
+and open address displayed in the terminal after `Local:` in the web browser.
+
+To see other ways of running the application see Available scripts below. To execute them, make sure to run them in the project folder.
+
 ### Available Scripts
 
 In this project, you can run the following scripts:


### PR DESCRIPTION
## [Add setup instructions to README](https://github.com/SchemingCate/eCommerce-app/issues/22)

Added setup instructions into the README file

## Acceptance Criteria

  - [x] Step-by-step instructions for setting up and running the project locally are available in the README file.
  - [x] Instructions are clear and easy to follow.

## Why the PR should be merged?

To provide clear setup instructions to the repository viewers.

## Self check

- [x] I did a self review of my code, removed comments and unnecessary logs.

  After creating the PR:

  - [ ] I’ve assigned at least two reviewers and sent a link into the discord #waiting-for-review channel;
  - [ ] A corresponding ticket is moved to the “Waiting for a review” column on a kanban board;
  - [ ] The corresponding issue is linked to the PR.