### PR TITLE
feat: add functionality  for the clear cart button

### DIFF
--- a/src/components/CartOrder/CartOrder.tsx
+++ b/src/components/CartOrder/CartOrder.tsx
@@ -2,6 +2,8 @@ import Button from 'shared/Button/Button';
 
 import currencyCodeToSymbol from 'utils/helpers/currencyCodeToSymbol';
 import { CentPrecisionMoney } from '@commercetools/platform-sdk';
+import { useCartContext } from 'context/cart-context';
+import useApiContext from 'context/context';
 import styles from './CartOrder.module.scss';
 
 interface Props {
@@ -13,6 +15,17 @@ function CartOrder({ totalPrice, productsCount }: Props) {
   const { centAmount, currencyCode } = totalPrice;
   const currencySymbol = currencyCodeToSymbol(currencyCode);
   const price = centAmount / 100;
+
+  const { setCart } = useCartContext();
+  const { cartService } = useApiContext();
+
+  function clearShoppingCart() {
+    cartService.removeAllGoods().then(() => {
+      cartService.getCart().then((cart) => {
+        if (cart) setCart(cart);
+      });
+    });
+  }
 
   return (
     <div className={styles.container}>
@@ -32,7 +45,7 @@ function CartOrder({ totalPrice, productsCount }: Props) {
         </div>
       </div>
       <div className={styles.remove_btn}>
-        <Button label="Clear the basket" />
+        <Button label="Clear the basket" handleClick={() => clearShoppingCart()} />
       </div>
     </div>
   );


### PR DESCRIPTION
📚 Description
Implement a feature that allows users to clear all items from their shopping cart at once 🛍️. This feature should be easy to access 🖱️ but designed to prevent accidental usage 🚫.

💻🔧 Implementation Details
"Clear Shopping Cart" Button 🗑️: This button should be prominently displayed within the user's shopping cart interface 🛒. It should be clearly labeled 🏷️ to avoid any confusion about its functionality.
Functionality 🚀: When clicked, the "Clear Shopping Cart" button should remove all items from the user's shopping cart and update the cart data in the commercetools API 🔄.
✅🎯 Acceptance Criteria
The shopping cart interface includes a "Clear Shopping Cart" button 🗑️.
Clicking the "Clear Shopping Cart" button removes all items from the shopping cart 🛒.
A confirmation prompt appears when the "Clear Shopping Cart" button is clicked 🚦.
